### PR TITLE
programmable usage for concatenating address property together

### DIFF
--- a/guides/concatenate-complete-adresse-in-single-property.md
+++ b/guides/concatenate-complete-adresse-in-single-property.md
@@ -1,0 +1,3 @@
+This custom coded action can concatenate all the address properties into a single string and output it as 'completeAddress'.
+
+It takes the properties 'address', 'city', 'state', 'country' and concatenates them together in a single string and outputs the string as an output named 'completeAddress'.

--- a/samples/concatenate-complete-adresse-in-single-property.js
+++ b/samples/concatenate-complete-adresse-in-single-property.js
@@ -1,0 +1,14 @@
+exports.main = (event, callback) => {
+  const address = event.inputFields['address'];
+  const city = event.inputFields['city'];
+  const state = event.inputFields['state'];
+  const country = event.inputFields['country'];
+  const zip = event.inputFields['zip'];
+
+  const completeAddress = `${address}, ${city}, ${state}, ${country}, ${zip}`;
+  callback({
+    outputFields: {
+      completeAddress: completeAddress,
+    },
+  });
+};


### PR DESCRIPTION
This custom coded action can concatenate all the address properties into a single string and output it as 'completeAddress'.

It takes the properties 'address', 'city', 'state', 'country' and concatenates them together in a single string and outputs the string as an output named 'completeAddress'.