### PR TITLE
Geolocate by company domain

### DIFF
--- a/guides/geolocate_by_company_domain.md
+++ b/guides/geolocate_by_company_domain.md
@@ -1,0 +1,11 @@
+This action is based on a company trigger.
+- Each time a company is added and the domain name is known.
+- We take the domain and converts it to an ip adress with the built in dns Node.js module.
+- Then we geolocate the ip address to get a postal address, with the ip-api.com service.
+- After that we set those values in the company record :
+```JavaScript
+{
+  "server_location": serverLocation,
+   "server_provider": serverProvider
+}
+```

--- a/samples/geolocate_by_company_domain.js
+++ b/samples/geolocate_by_company_domain.js
@@ -1,0 +1,59 @@
+const hubspot = require('@hubspot/api-client');
+const axios = require('axios');
+
+const dns = require('dns');
+
+const lookupPromise = url =>
+  new Promise((resolve, reject) => {
+    dns.lookup(url, (err, address, family) => {
+      if (err) reject(err);
+      resolve(address);
+    });
+  });
+
+exports.main = async (event, callback) => {
+  try {
+    const companyDomain = event.inputFields.domain;
+
+    if (!companyDomain)
+      throw new Error(`company domain is undefined we got ${companyDomain}`);
+
+    console.log(`the companyDomain is ${companyDomain}`);
+
+    const ip = await lookupPromise(companyDomain);
+
+    console.log(`ìp for ${companyDomain} is ${ip}`);
+
+    const geoLoc = await axios.get(`http://ip-api.com/json/${ip}`);
+
+    if (!geoLoc.data || geoLoc.data.status !== 'success')
+      throw new Error(`We failed to geolocate ${ip}... 😬`);
+
+    const serverLocation = `${geoLoc.data.city}, ${geoLoc.data.regionName}, ${geoLoc.data.country}`;
+
+    if (!serverLocation)
+      throw new Error(
+        `We can't continue serverLocation is falsy we got ${serverLocation}... 😬`
+      );
+
+    const serverProvider = geoLoc.data.isp ? geoLoc.data.isp : '';
+
+    const properties = {
+      server_location: serverLocation,
+      server_provider: serverProvider.toLowerCase(),
+    };
+
+    console.log(JSON.stringify(properties));
+
+    callback({
+      outputFields: {
+        server_location: serverLocation,
+        server_provider: serverProvider,
+      },
+    });
+  } catch (err) {
+    console.error(err);
+    // We will automatically retry when the code fails because of a rate limiting error from the HubSpot API.
+    throw err;
+  }
+};


### PR DESCRIPTION
This action is based on a company trigger.
- Each time a company is added and the domain name is known.
- We take the domain and converts it to an ip adress with the built in dns Node.js module.
- Then we geolocate the ip address to get a postal address, with the ip-api.com service.
- After that we set those values in the company record :
```JavaScript
{
  "server_location": serverLocation,
   "server_provider": serverProvider
}
```